### PR TITLE
Hotfix for SelectedItem on DataGrid

### DIFF
--- a/WPFUI/Models/Conversation.cs
+++ b/WPFUI/Models/Conversation.cs
@@ -43,8 +43,7 @@ public partial class Conversation : ObservableObject, IEquatable<Conversation>
 
     public override bool Equals(object? obj) => obj is not null && Equals(obj as Conversation);
 
-    public override int GetHashCode() =>
-        (Name, OriginalText, EditedText, Sound, Context, NpcName, Type, Voice, Number, IsEdited, IsInspected).GetHashCode();
+    public override int GetHashCode() => Name.GetHashCode();
 
     public bool Equals(Conversation? other)
     {

--- a/WPFUI/Views/MainWindow.xaml
+++ b/WPFUI/Views/MainWindow.xaml
@@ -187,7 +187,7 @@
         <Grid Grid.Row="2" Grid.Column="1">
             <cc:DataGrid x:Name="DataGrid_Upper" Grid.Row="2"
                 ItemsSource="{Binding ConversationCollection}"
-                SelectionMode="Single"
+                SelectionMode="Single" IsReadOnly="True"
                 HeadersVisibility="Column" AutoGenerateColumns="False"                         
                 CanUserAddRows="False" CanUserDeleteRows="False" CanUserReorderColumns="True"
                 CanUserResizeColumns="True" CanUserResizeRows="True" CanUserSortColumns="True"
@@ -271,7 +271,7 @@
         <Grid Grid.Row="3" Grid.Column="1">
             <cc:DataGrid x:Name="DataGrid_Lower" Grid.Row="2"
                 ItemsSource="{Binding Source={StaticResource LowerDataGridCVS}}"
-                SelectionMode="Single"
+                SelectionMode="Single" IsReadOnly="True"
                 HeadersVisibility="Column" AutoGenerateColumns="False"
                 CanUserAddRows="False" CanUserDeleteRows="False" CanUserReorderColumns="True"
                 CanUserResizeColumns="True" CanUserResizeRows="True" CanUserSortColumns="True"


### PR DESCRIPTION
Fix for #3 
Changed `GetHashCode()` method in `Conversation` class. I decided that 'uniqueness' property for this class will be `Name`.
Since `Name` is used as key selector in `CompareTo` method when comparing two files/projects.
Both DataGrids has been set their `IsReadOnly` properties to `True` to avoid unnecessary complications.