### PR TITLE
Fixed refreshing Inspected and Edited count in footer upon loading procject

### DIFF
--- a/WPFUI/ViewModels/MainWindowViewModel.cs
+++ b/WPFUI/ViewModels/MainWindowViewModel.cs
@@ -357,6 +357,8 @@ public partial class MainWindowViewModel : ObservableObject
         ConversationCollection.Refresh();
         OnPropertyChanged(nameof(LoadedNPCsCount));
         OnPropertyChanged(nameof(FilteredConversationsCount));
+        OnPropertyChanged(nameof(EditedConversationsCount));
+        OnPropertyChanged(nameof(InspectedConversationsCount));
         _projectWasEdited = false;
     }
 


### PR DESCRIPTION
As the title indicates.
I changed `CleanReloadRefreshConversationCollection` method. Actually it's used by Import and Load methods, but when import `OU` file is done there is no need to change Edited and Inspected count since it will always be 0.
I decided to edit this method anyway for more clarity.