### PR TITLE
Fixed: Inspected and Edited count in footer not refreshing limitedly after change `Conversation` corresponding property

### DIFF
--- a/WPFUI/ViewModels/MainWindowViewModel.cs
+++ b/WPFUI/ViewModels/MainWindowViewModel.cs
@@ -443,6 +443,7 @@ public partial class MainWindowViewModel : ObservableObject
     {
         var edited = !SelectedConversation.EditedText.Equals(SelectedConversation.OriginalText);
         SelectedConversation.IsEdited = edited;
+        OnPropertyChanged(nameof(EditedConversationsCount));
 
         if (edited)
             ProjectFileChanged();
@@ -675,6 +676,7 @@ public partial class MainWindowViewModel : ObservableObject
     [RelayCommand]
     private void ProjectFileChanged()
     {
+        OnPropertyChanged(nameof(InspectedConversationsCount));        
         if (_projectWasEdited)
             return;
 

--- a/WPFUI/Views/MainWindow.xaml
+++ b/WPFUI/Views/MainWindow.xaml
@@ -200,9 +200,8 @@
                     <DataGridTemplateColumn Header="Audio">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <Button Command="{Binding RelativeSource={RelativeSource Mode=FindAncestor,
-                                    AncestorType={x:Type Window}},
-                                    Path=DataContext.StartPlaybackCommand}" VerticalAlignment="Center" HorizontalAlignment="Center">
+                                <Button Command="{Binding Path=DataContext.StartPlaybackCommand, Source={x:Reference DataGrid_Upper}}"
+                                    VerticalAlignment="Center" HorizontalAlignment="Center">
                                     <fa:ImageAwesome Icon="Solid_Play" Height="12" Width="12" PrimaryColor="White" />
                                 </Button>
                             </DataTemplate>
@@ -214,7 +213,7 @@
                             <DataTemplate>
                                 <CheckBox VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
                                     IsChecked="{Binding IsInspected, UpdateSourceTrigger=PropertyChanged}"
-                                    Command="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=DataContext.ProjectFileChangedCommand}" />
+                                    Command="{Binding Path=DataContext.ProjectFileChangedCommand, Source={x:Reference DataGrid_Upper}}" />
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
@@ -297,9 +296,8 @@
                     <DataGridTemplateColumn Header="Audio">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <Button Command="{Binding RelativeSource={RelativeSource Mode=FindAncestor,
-                                    AncestorType={x:Type Window}},
-                                    Path=DataContext.StartPlaybackCommand}" VerticalAlignment="Center" HorizontalAlignment="Center">
+                                <Button Command="{Binding Path=DataContext.StartPlaybackCommand, Source={x:Reference DataGrid_Lower}}"
+                                    VerticalAlignment="Center" HorizontalAlignment="Center">
                                     <fa:ImageAwesome Icon="Solid_Play" Height="12" Width="12" PrimaryColor="White" />
                                 </Button>
                             </DataTemplate>
@@ -311,7 +309,7 @@
                             <DataTemplate>
                                 <CheckBox VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
                                     IsChecked="{Binding IsInspected, UpdateSourceTrigger=PropertyChanged}"
-                                    Command="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=DataContext.ProjectFileChangedCommand}" />
+                                    Command="{Binding Path=DataContext.ProjectFileChangedCommand, Source={x:Reference DataGrid_Lower}}" />
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>


### PR DESCRIPTION
I've added `OnPropertyChanged` for `EditedConversationsCount` and `InspectedConversationsCount` that will count them immediately after change corresponding property in `Converastion`.
Footer is more responsive now.