### PR TITLE
Change Ignore Inspected to Force Check Inspected in Compare Mode

### DIFF
--- a/WPFUI/ViewModels/MainWindowViewModel.cs
+++ b/WPFUI/ViewModels/MainWindowViewModel.cs
@@ -15,6 +15,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Data;
 using System.Windows.Forms;
+using WPFUI.Comparer;
 using WPFUI.Components;
 using WPFUI.Enums;
 using WPFUI.Extensions;
@@ -722,8 +723,19 @@ public partial class MainWindowViewModel : ObservableObject
                     _conversationList.Add(SelectedConversationDiff.Diff.Compared);
                 break;
             case ComparisonResultType.Changed:
-                if (IsEnabledIgnoreInspectedWhileTransfer && SelectedConversationDiff.Diff.Variances.ContainsKey("IsInspected"))
-                    SelectedConversationDiff.Diff.Variances.Remove("IsInspected");
+                if (IsEnabledIgnoreInspectedWhileTransfer)
+                {
+                    if (!SelectedConversationDiff.Diff.Variances.TryGetValue(nameof(Conversation.IsInspected), out ComparisonVariance? value))
+                    {
+                        SelectedConversationDiff.Diff.Variances
+                            .Add(nameof(Conversation.IsInspected), new ComparisonVariance { PropertyName = nameof(Conversation.IsInspected), ValA = true, ValB = true });
+                    }
+                    else
+                    {
+                        value.ValB = true;
+                    }
+                    SelectedConversationDiff.Diff.Compared!.IsInspected = true;
+                }
 
                 SelectedConversationDiff.Diff.Compared.TransferTo(SelectedConversationDiff.Diff.Original, SelectedConversationDiff.Diff.Variances);
                 break;

--- a/WPFUI/Views/CompareWindow.xaml
+++ b/WPFUI/Views/CompareWindow.xaml
@@ -239,16 +239,16 @@
                     <fa:ImageAwesome Icon="Solid_Xmark" Height="20" PrimaryColor="DarkCyan" />
                 </Button>
                 <TextBlock Margin="0 0 0 10" Text="Discard" HorizontalAlignment="Center" />
-                
+
                 <Button HorizontalAlignment="Center" VerticalAlignment="Center"
                     Command="{Binding AcceptComparedChangesCommand}">
                     <fa:ImageAwesome Icon="Solid_ArrowLeft" Height="20" PrimaryColor="DarkCyan" />
                 </Button>
                 <TextBlock Text="{Binding SelectedConversationDiff.Diff.Type, Converter={StaticResource ComparisonResultTypeConverter}, FallbackValue=-}"
                     HorizontalAlignment="Center" />
-                
+
                 <CheckBox Visibility="{Binding SelectedConversationDiff.Diff.Type, Converter={StaticResource ComparisonResultTypeToVisibilityConverter}, FallbackValue=Hidden}"
-                    Margin="0 15 0 0" FontSize="10" Content="Ignore Inspected" IsChecked="{Binding IsEnabledIgnoreInspectedWhileTransfer}" />
+                    Margin="0 15 0 0" FontSize="10" Content="Force Check Inspected" IsChecked="{Binding IsEnabledIgnoreInspectedWhileTransfer}" />
             </StackPanel>
         </Grid>
 


### PR DESCRIPTION
It's more likely to have option to force check inspected rather than ignore it.
In Compare Mode you actually compare two `Conversation` (Captain Obvious 😛) so you want to set compared `Conversation` as inspected even if compared one wasn't set as `IsInspected`.