### PR TITLE
Fixed binding to wrong property in `SelectedItem` in CompareMode

### DIFF
--- a/WPFUI/Views/CompareWindow.xaml
+++ b/WPFUI/Views/CompareWindow.xaml
@@ -142,7 +142,7 @@
                 CanUserAddRows="False" CanUserDeleteRows="False" CanUserReorderColumns="True"
                 CanUserResizeColumns="True" CanUserResizeRows="True" CanUserSortColumns="True"
                 ScrollViewer.VerticalScrollBarVisibility="Visible"
-                SelectedItem="{Binding SelectedConversationDiff}"
+                SelectedItem="{Binding SelectedGridRow}"
                 VirtualizingStackPanel.IsVirtualizing="True" VirtualizingStackPanel.IsVirtualizingWhenGrouping="True"
                 VirtualizingStackPanel.VirtualizationMode="Recycling"
                 IsSynchronizedWithCurrentItem="True">


### PR DESCRIPTION
Accidentally caused by #13