### PR TITLE
 Fixed audio volume bar value when loading save

### DIFF
--- a/WPFUI/ViewModels/MainWindowViewModel.cs
+++ b/WPFUI/ViewModels/MainWindowViewModel.cs
@@ -546,7 +546,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, ICloseable
                 AudioPlayerViewModel.Volume = projectFile.AudioPlayerVolume;
 
             if (projectFile.AudioPlayerPreviousVolume >= 0f && projectFile.AudioPlayerPreviousVolume <= 1f)
-                _settingsService.AudioPlayerVolume = projectFile.AudioPlayerPreviousVolume;
+                _settingsService.AudioPlayerPreviousVolume = projectFile.AudioPlayerPreviousVolume;
 
             IsEnabledFilterName = projectFile.EnabledFilterName;
             IsEnabledFilterOriginalText = projectFile.EnabledFilterOriginalText;


### PR DESCRIPTION
Happen in #13. `AudioPlayerVolume` was set instead `AudioPlayerPreviousVolume` when loading save file so both audio bar values were wrong after load.