### PR TITLE
Fix: Possibility to accidentally override project file when first open ten import other file

### DIFF
--- a/WPFUI/ViewModels/MainWindowViewModel.cs
+++ b/WPFUI/ViewModels/MainWindowViewModel.cs
@@ -473,6 +473,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, ICloseable
         CleanReloadRefreshConversationCollection();
         IsOuFileImported = true;
         Title = TITLE + " - NewProject";
+        _settingsService.MainPathToSaveFile = string.Empty;
         ProjectFileChanged();
     }
 


### PR DESCRIPTION
There was possibility to load project then import `bin` file and save imported file without any warning and override previously loaded project.