### PR TITLE
Feat: Rearranged DetailedPanel in normal and compare mode, added Copy to Clipboard buttons

### DIFF
--- a/WPFUI/App.xaml
+++ b/WPFUI/App.xaml
@@ -31,6 +31,15 @@
                 <Setter Property="Margin" Value="15 0 0 0" />
                 <Setter Property="IsReadOnly" Value="True" />
             </Style>
+            <Style x:Key="CopyButton" BasedOn="{StaticResource {x:Type Button}}" TargetType="Button">
+                <Setter Property="Height" Value="22" />
+                <Setter Property="Padding" Value="1" />
+                <Setter Property="Background" Value="Transparent"/>
+                <Setter Property="Cursor" Value="Hand" />
+                <Setter Property="Margin" Value="5 0 0 0" />
+                <Setter Property="VerticalAlignment" Value="Stretch" />
+                <Setter Property="HorizontalAlignment" Value="Stretch" />
+            </Style>
             <converters:PlaybackStateConverter x:Key="PlaybackStateConverter" />
             <converters:MuteButtonConverter x:Key="MuteButtonConverter" />
             <converters:VolumeConverter x:Key="VolumeConverter" />

--- a/WPFUI/App.xaml
+++ b/WPFUI/App.xaml
@@ -39,6 +39,7 @@
                 <Setter Property="Margin" Value="5 0 0 0" />
                 <Setter Property="VerticalAlignment" Value="Stretch" />
                 <Setter Property="HorizontalAlignment" Value="Stretch" />
+                <Setter Property="ToolTip" Value="Copy to Clipboard" />
             </Style>
             <converters:PlaybackStateConverter x:Key="PlaybackStateConverter" />
             <converters:MuteButtonConverter x:Key="MuteButtonConverter" />

--- a/WPFUI/App.xaml
+++ b/WPFUI/App.xaml
@@ -23,8 +23,9 @@
             </Style>
             <Style x:Key="SmoothTexBox" BasedOn="{StaticResource DefaultTextBoxStyle}" TargetType="TextBox">
                 <Setter Property="MinWidth" Value="0" />
+                <Setter Property="MinHeight" Value="0" />
                 <Setter Property="Padding" Value="5 3" />
-                <Setter Property="HorizontalAlignment" Value="Center" />
+                <Setter Property="HorizontalAlignment" Value="Left" />
                 <Setter Property="VerticalAlignment" Value="Center" />
                 <Setter Property="TextAlignment" Value="Center" />
                 <Setter Property="Margin" Value="15 0 0 0" />

--- a/WPFUI/ViewModels/MainWindowViewModel.cs
+++ b/WPFUI/ViewModels/MainWindowViewModel.cs
@@ -339,6 +339,13 @@ public sealed partial class MainWindowViewModel : ObservableObject, ICloseable
     }
 
     [RelayCommand]
+    private static void CopyToClipboard(object value)
+    {
+        if (value is string text && !string.IsNullOrEmpty(text))
+            Clipboard.SetText(text);
+    }
+
+    [RelayCommand]
     private void ChangeEncoding(EncodingMenuItem value)
     {
         foreach (var encodingMenuItem in Encodings)

--- a/WPFUI/Views/CompareWindow.xaml
+++ b/WPFUI/Views/CompareWindow.xaml
@@ -168,71 +168,150 @@
             </cc:DataGrid>
         </Grid>
 
-
         <Grid Grid.Row="2" Grid.RowSpan="2" Grid.Column="1">
-            <DockPanel>
-                <TextBlock DockPanel.Dock="Top" HorizontalAlignment="Center" Margin="0 6"
-                    FontWeight="Bold" Foreground="DarkOrange">Original</TextBlock>
-                <ScrollViewer BorderThickness="1 0 1 0" BorderBrush="Black">
-                    <StackPanel Margin="5 5 5 5">
-                        <WrapPanel Orientation="Horizontal" Margin="5 5 0 5" VerticalAlignment="Center">
-                            <TextBlock VerticalAlignment="Center" Foreground="{Binding PropertyColor.Type, Converter={StaticResource BoolToColorConverter}}">Type</TextBlock>
-                            <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversationDiff.Diff.Original.Type}" />
-                        </WrapPanel>
-                        <WrapPanel Orientation="Horizontal" Margin="5 5 0 5">
-                            <TextBlock VerticalAlignment="Center" Foreground="{Binding PropertyColor.Name, Converter={StaticResource BoolToColorConverter}}">Name</TextBlock>
-                            <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversationDiff.Diff.Original.Name}" />
-                        </WrapPanel>
-                        <WrapPanel Orientation="Horizontal" Margin="5 5 0 5">
-                            <TextBlock VerticalAlignment="Center" Foreground="{Binding PropertyColor.Sound, Converter={StaticResource BoolToColorConverter}}">Sound</TextBlock>
-                            <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversationDiff.Diff.Original.Sound}" />
-                        </WrapPanel>
-                        <WrapPanel Orientation="Horizontal" Margin="5 5 0 5">
-                            <TextBlock VerticalAlignment="Center" Foreground="{Binding PropertyColor.NpcName, Converter={StaticResource BoolToColorConverter}}">NPC Name</TextBlock>
-                            <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversationDiff.Diff.Original.NpcName}" />
-                        </WrapPanel>
-                        <WrapPanel Orientation="Horizontal" Margin="5 5 0 5">
-                            <TextBlock VerticalAlignment="Center" Foreground="{Binding PropertyColor.Context, Converter={StaticResource BoolToColorConverter}}">Context</TextBlock>
-                            <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversationDiff.Diff.Original.Context}" />
-                        </WrapPanel>
-                        <WrapPanel Orientation="Horizontal" Margin="5 5 0 5">
-                            <TextBlock VerticalAlignment="Center" Foreground="{Binding PropertyColor.Voice, Converter={StaticResource BoolToColorConverter}}">Voice</TextBlock>
-                            <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversationDiff.Diff.Original.Voice}" />
-                        </WrapPanel>
-                        <WrapPanel Orientation="Horizontal" Margin="5 5 0 5">
-                            <TextBlock VerticalAlignment="Center" Foreground="{Binding PropertyColor.Number, Converter={StaticResource BoolToColorConverter}}">Number</TextBlock>
-                            <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversationDiff.Diff.Original.Number}" />
-                        </WrapPanel>
-                        <DockPanel LastChildFill="False">
+            <ScrollViewer BorderThickness="1 0 1 0" BorderBrush="Black" HorizontalScrollBarVisibility="Auto">
+                <StackPanel>
+                    <TextBlock HorizontalAlignment="Center" Margin="0 6" FontWeight="Bold" Foreground="DarkOrange">Original</TextBlock>
+                    <Grid Grid.IsSharedSizeScope="True" Margin="5 5 0 0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                        </Grid.RowDefinitions>
+                         
+                        <Grid Grid.Row="0" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0" Foreground="{Binding PropertyColor.Type, Converter={StaticResource BoolToColorConverter}}">Type</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding MainWindowViewModel.CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Original_Type}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Original_Type" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversationDiff.Diff.Original.Type}" />
+                        </Grid>
+
+                        <Grid Grid.Row="1" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0" Foreground="{Binding PropertyColor.Name, Converter={StaticResource BoolToColorConverter}}">Name</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding MainWindowViewModel.CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Original_Name}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Original_Name" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversationDiff.Diff.Original.Name}" />
+                        </Grid>
+
+                        <Grid Grid.Row="2" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0" Foreground="{Binding PropertyColor.Sound, Converter={StaticResource BoolToColorConverter}}">Sound</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding MainWindowViewModel.CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Original_Sound}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Original_Sound" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversationDiff.Diff.Original.Sound}" />
+                        </Grid>
+
+                        <Grid Grid.Row="3" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0" Foreground="{Binding PropertyColor.NpcName, Converter={StaticResource BoolToColorConverter}}">NPC Name</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding MainWindowViewModel.CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Original_NpcName}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Original_NpcName" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversationDiff.Diff.Original.NpcName}" />
+                        </Grid>
+
+                        <Grid Grid.Row="4" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0" Foreground="{Binding PropertyColor.Context, Converter={StaticResource BoolToColorConverter}}">Context</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding MainWindowViewModel.CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Original_Context}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Original_Context" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversationDiff.Diff.Original.Context}" />
+                        </Grid>
+
+                        <Grid Grid.Row="5" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0" Foreground="{Binding PropertyColor.Voice, Converter={StaticResource BoolToColorConverter}}">Voice</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding MainWindowViewModel.CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Original_Voice}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Original_Voice" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversationDiff.Diff.Original.Voice}" />
+                        </Grid>
+
+                        <Grid Grid.Row="6" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0" Foreground="{Binding PropertyColor.Number, Converter={StaticResource BoolToColorConverter}}">Number</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding MainWindowViewModel.CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Original_Number}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Original_Number" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversationDiff.Diff.Original.Number}" />
+                        </Grid>
+
+                        <DockPanel LastChildFill="False" Grid.Row="7">
                             <WrapPanel DockPanel.Dock="Left" Orientation="Horizontal" Margin="5 5 0 5">
-                                <TextBlock VerticalAlignment="Center" Text="Inspected" Foreground="{Binding PropertyColor.Inspected, Converter={StaticResource BoolToColorConverter}}" />
-                                <CheckBox Margin="15 0 0 0" VerticalAlignment="Center" HorizontalAlignment="Center" Focusable="False" IsHitTestVisible="False" IsChecked="{Binding SelectedConversationDiff.Diff.Original.IsInspected}" />
+                                <TextBlock VerticalAlignment="Center" Foreground="{Binding PropertyColor.Inspected, Converter={StaticResource BoolToColorConverter}}">Inspected</TextBlock>
+                                <CheckBox Margin="15 0 0 0" VerticalAlignment="Center" HorizontalAlignment="Center" IsChecked="{Binding SelectedConversationDiff.Diff.Original.IsInspected}"
+                                    Focusable="False" IsHitTestVisible="False"/>
                             </WrapPanel>
                             <WrapPanel DockPanel.Dock="Right" Orientation="Horizontal" Margin="5 5 0 5">
                                 <TextBlock VerticalAlignment="Center" Foreground="{Binding PropertyColor.Edited, Converter={StaticResource BoolToColorConverter}}">Edited</TextBlock>
                                 <CheckBox Margin="15 0 0 0" VerticalAlignment="Center" HorizontalAlignment="Center" Focusable="False" IsHitTestVisible="False" IsChecked="{Binding SelectedConversationDiff.Diff.Original.IsEdited}" />
                             </WrapPanel>
                         </DockPanel>
-                        <StackPanel Margin="5 15 0 5" HorizontalAlignment="Center">
-                            <TextBlock HorizontalAlignment="Center" Foreground="{Binding PropertyColor.OriginalText, Converter={StaticResource BoolToColorConverter}}">Original Text</TextBlock>
-                            <TextBox VerticalScrollBarVisibility="Auto" Width="300" MinLines="3" MaxLines="10" Padding="4"
-                             TextWrapping="Wrap" MouseDoubleClick="TextBox_CopyToClipboard"
-                             IsReadOnly="True"
-                             Text="{Binding SelectedConversationDiff.Diff.Original.OriginalText}" />
-                        </StackPanel>
-                        <StackPanel Margin="5 15 0 5" HorizontalAlignment="Center">
-                            <TextBlock HorizontalAlignment="Center" Foreground="{Binding PropertyColor.EditedText, Converter={StaticResource BoolToColorConverter}}">Edited Text</TextBlock>
-                            <TextBox VerticalScrollBarVisibility="Auto" Width="300" MinLines="3" MaxLines="10" Padding="4"
-                             TextWrapping="Wrap" MouseDoubleClick="TextBox_CopyToClipboard"
-                             IsReadOnly="True"
-                             SpellCheck.IsEnabled="True" Language="pl-PL"
-                             Text="{Binding SelectedConversationDiff.Diff.Original.EditedText, UpdateSourceTrigger=PropertyChanged}">
-                            </TextBox>
-                        </StackPanel>
+                    </Grid>
 
+                    <StackPanel Margin="5 15 0 5" HorizontalAlignment="Center">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock HorizontalAlignment="Center" Foreground="{Binding PropertyColor.OriginalText, Converter={StaticResource BoolToColorConverter}}">Original Text</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding MainWindowViewModel.CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Original_OriginalText}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                        </StackPanel>
+                        <TextBox x:Name="Original_OriginalText" VerticalScrollBarVisibility="Auto" Width="300" MinLines="3" MaxLines="10" Padding="4"
+                            TextWrapping="Wrap" IsReadOnly="True" Text="{Binding SelectedConversationDiff.Diff.Original.OriginalText}" />
                     </StackPanel>
-                </ScrollViewer>
-            </DockPanel>
+                    <StackPanel Margin="5 15 0 5" HorizontalAlignment="Center">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock HorizontalAlignment="Center" Foreground="{Binding PropertyColor.EditedText, Converter={StaticResource BoolToColorConverter}}">Edited Text</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding MainWindowViewModel.CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Original_EditedText}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                        </StackPanel>
+                        <TextBox x:Name="Original_EditedText" VerticalScrollBarVisibility="Auto" Width="300" MinLines="3" MaxLines="10" Padding="4"
+                             TextWrapping="Wrap" SpellCheck.IsEnabled="True" Language="pl-PL" IsReadOnly="True"
+                             Text="{Binding SelectedConversationDiff.Diff.Original.EditedText, UpdateSourceTrigger=PropertyChanged}">
+                        </TextBox>
+                    </StackPanel>
+                </StackPanel>
+            </ScrollViewer>
         </Grid>
 
         <Grid Grid.Row="2" Grid.Column="2" Grid.RowSpan="2">
@@ -256,70 +335,149 @@
         </Grid>
 
         <Grid Grid.Row="2" Grid.Column="3" x:Name="DetailedPanel" Grid.RowSpan="2">
+            <ScrollViewer BorderThickness="1 0 1 0" BorderBrush="Black" HorizontalScrollBarVisibility="Auto">
+                <StackPanel>
+                    <TextBlock HorizontalAlignment="Center" Margin="0 6" FontWeight="Bold" Foreground="DarkOrange">Imported</TextBlock>
+                    <Grid Grid.IsSharedSizeScope="True" Margin="5 5 0 0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                        </Grid.RowDefinitions>
 
-            <DockPanel>
-                <TextBlock DockPanel.Dock="Top" HorizontalAlignment="Center" Margin="0 6"
-                    FontWeight="Bold" Foreground="DarkOrange">Imported</TextBlock>
-                <ScrollViewer BorderThickness="1 0 0 0" BorderBrush="Black">
-                    <StackPanel Margin="5 5 5 5">
-                        <WrapPanel Orientation="Horizontal" Margin="5 5 0 5" VerticalAlignment="Center">
-                            <TextBlock VerticalAlignment="Center" Foreground="{Binding PropertyColor.Type, Converter={StaticResource BoolToColorConverter}}">Type</TextBlock>
-                            <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversationDiff.Diff.Compared.Type}" />
-                        </WrapPanel>
-                        <WrapPanel Orientation="Horizontal" Margin="5 5 0 5">
-                            <TextBlock VerticalAlignment="Center" Foreground="{Binding PropertyColor.Name, Converter={StaticResource BoolToColorConverter}}">Name</TextBlock>
-                            <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversationDiff.Diff.Compared.Name}" />
-                        </WrapPanel>
-                        <WrapPanel Orientation="Horizontal" Margin="5 5 0 5">
-                            <TextBlock VerticalAlignment="Center" Foreground="{Binding PropertyColor.Sound, Converter={StaticResource BoolToColorConverter}}">Sound</TextBlock>
-                            <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversationDiff.Diff.Compared.Sound}" />
-                        </WrapPanel>
-                        <WrapPanel Orientation="Horizontal" Margin="5 5 0 5">
-                            <TextBlock VerticalAlignment="Center" Foreground="{Binding PropertyColor.NpcName, Converter={StaticResource BoolToColorConverter}}">NPC Name</TextBlock>
-                            <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversationDiff.Diff.Compared.NpcName}" />
-                        </WrapPanel>
-                        <WrapPanel Orientation="Horizontal" Margin="5 5 0 5">
-                            <TextBlock VerticalAlignment="Center" Foreground="{Binding PropertyColor.Context, Converter={StaticResource BoolToColorConverter}}">Context</TextBlock>
-                            <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversationDiff.Diff.Compared.Context}" />
-                        </WrapPanel>
-                        <WrapPanel Orientation="Horizontal" Margin="5 5 0 5">
-                            <TextBlock VerticalAlignment="Center" Foreground="{Binding PropertyColor.Voice, Converter={StaticResource BoolToColorConverter}}">Voice</TextBlock>
-                            <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversationDiff.Diff.Compared.Voice}" />
-                        </WrapPanel>
-                        <WrapPanel Orientation="Horizontal" Margin="5 5 0 5">
-                            <TextBlock VerticalAlignment="Center" Foreground="{Binding PropertyColor.Number, Converter={StaticResource BoolToColorConverter}}">Number</TextBlock>
-                            <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversationDiff.Diff.Compared.Number}" />
-                        </WrapPanel>
-                        <DockPanel LastChildFill="False">
+                        <Grid Grid.Row="0" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0" Foreground="{Binding PropertyColor.Type, Converter={StaticResource BoolToColorConverter}}">Type</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding MainWindowViewModel.CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Imported_Type}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Imported_Type" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversationDiff.Diff.Compared.Type}" />
+                        </Grid>
+
+                        <Grid Grid.Row="1" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0" Foreground="{Binding PropertyColor.Name, Converter={StaticResource BoolToColorConverter}}">Name</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding MainWindowViewModel.CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Imported_Name}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Imported_Name" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversationDiff.Diff.Compared.Name}" />
+                        </Grid>
+
+                        <Grid Grid.Row="2" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0" Foreground="{Binding PropertyColor.Sound, Converter={StaticResource BoolToColorConverter}}">Sound</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding MainWindowViewModel.CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Imported_Sound}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Imported_Sound" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversationDiff.Diff.Compared.Sound}" />
+                        </Grid>
+
+                        <Grid Grid.Row="3" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0" Foreground="{Binding PropertyColor.NpcName, Converter={StaticResource BoolToColorConverter}}">NPC Name</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding MainWindowViewModel.CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Imported_NpcName}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Imported_NpcName" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversationDiff.Diff.Compared.NpcName}" />
+                        </Grid>
+
+                        <Grid Grid.Row="4" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0" Foreground="{Binding PropertyColor.Context, Converter={StaticResource BoolToColorConverter}}">Context</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding MainWindowViewModel.CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Imported_Context}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Imported_Context" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversationDiff.Diff.Compared.Context}" />
+                        </Grid>
+
+                        <Grid Grid.Row="5" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0" Foreground="{Binding PropertyColor.Voice, Converter={StaticResource BoolToColorConverter}}">Voice</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding MainWindowViewModel.CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Imported_Voice}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Imported_Voice" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversationDiff.Diff.Compared.Voice}" />
+                        </Grid>
+
+                        <Grid Grid.Row="6" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0" Foreground="{Binding PropertyColor.Number, Converter={StaticResource BoolToColorConverter}}">Number</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding MainWindowViewModel.CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Imported_Number}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Imported_Number" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversationDiff.Diff.Compared.Number}" />
+                        </Grid>
+
+                        <DockPanel LastChildFill="False" Grid.Row="7">
                             <WrapPanel DockPanel.Dock="Left" Orientation="Horizontal" Margin="5 5 0 5">
                                 <TextBlock VerticalAlignment="Center" Foreground="{Binding PropertyColor.Inspected, Converter={StaticResource BoolToColorConverter}}">Inspected</TextBlock>
-                                <CheckBox Margin="15 0 0 0" VerticalAlignment="Center" HorizontalAlignment="Center" Focusable="False" IsHitTestVisible="False" IsChecked="{Binding SelectedConversationDiff.Diff.Compared.IsInspected}" />
+                                <CheckBox Margin="15 0 0 0" VerticalAlignment="Center" HorizontalAlignment="Center" IsChecked="{Binding SelectedConversationDiff.Diff.Compared.IsInspected}"
+						            Focusable="False" IsHitTestVisible="False"/>
                             </WrapPanel>
                             <WrapPanel DockPanel.Dock="Right" Orientation="Horizontal" Margin="5 5 0 5">
                                 <TextBlock VerticalAlignment="Center" Foreground="{Binding PropertyColor.Edited, Converter={StaticResource BoolToColorConverter}}">Edited</TextBlock>
                                 <CheckBox Margin="15 0 0 0" VerticalAlignment="Center" HorizontalAlignment="Center" Focusable="False" IsHitTestVisible="False" IsChecked="{Binding SelectedConversationDiff.Diff.Compared.IsEdited}" />
                             </WrapPanel>
                         </DockPanel>
-                        <StackPanel Margin="5 15 0 5" HorizontalAlignment="Center">
-                            <TextBlock HorizontalAlignment="Center" Foreground="{Binding PropertyColor.OriginalText, Converter={StaticResource BoolToColorConverter}}">Original Text</TextBlock>
-                            <TextBox VerticalScrollBarVisibility="Auto" Width="300" MinLines="3" MaxLines="10" Padding="4"
-                             TextWrapping="Wrap" MouseDoubleClick="TextBox_CopyToClipboard"
-                             IsReadOnly="True"
-                             Text="{Binding SelectedConversationDiff.Diff.Compared.OriginalText}" />
-                        </StackPanel>
-                        <StackPanel Margin="5 15 0 5" HorizontalAlignment="Center">
-                            <TextBlock HorizontalAlignment="Center" Foreground="{Binding PropertyColor.EditedText, Converter={StaticResource BoolToColorConverter}}">Edited Text</TextBlock>
-                            <TextBox VerticalScrollBarVisibility="Auto" Width="300" MinLines="3" MaxLines="10" Padding="4"
-                             TextWrapping="Wrap" MouseDoubleClick="TextBox_CopyToClipboard"
-                             SpellCheck.IsEnabled="True" Language="pl-PL"
-                             IsReadOnly="True"
-                             Text="{Binding SelectedConversationDiff.Diff.Compared.EditedText, UpdateSourceTrigger=PropertyChanged}">
-                            </TextBox>
-                        </StackPanel>
+                    </Grid>
 
+                    <StackPanel Margin="5 15 0 5" HorizontalAlignment="Center">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock HorizontalAlignment="Center" Foreground="{Binding PropertyColor.OriginalText, Converter={StaticResource BoolToColorConverter}}">Original Text</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding MainWindowViewModel.CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Imported_OriginalText}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                        </StackPanel>
+                        <TextBox x:Name="Imported_OriginalText" VerticalScrollBarVisibility="Auto" Width="300" MinLines="3" MaxLines="10" Padding="4"
+				            TextWrapping="Wrap" IsReadOnly="True" Text="{Binding SelectedConversationDiff.Diff.Compared.OriginalText}" />
                     </StackPanel>
-                </ScrollViewer>
-            </DockPanel>
+                    <StackPanel Margin="5 15 0 5" HorizontalAlignment="Center">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock HorizontalAlignment="Center" Foreground="{Binding PropertyColor.EditedText, Converter={StaticResource BoolToColorConverter}}">Edited Text</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding MainWindowViewModel.CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Imported_EditedText}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                        </StackPanel>
+                        <TextBox x:Name="Imported_EditedText" VerticalScrollBarVisibility="Auto" Width="300" MinLines="3" MaxLines="10" Padding="4"
+				             TextWrapping="Wrap" SpellCheck.IsEnabled="True" Language="pl-PL" IsReadOnly="True"
+				             Text="{Binding SelectedConversationDiff.Diff.Compared.EditedText, UpdateSourceTrigger=PropertyChanged}">
+                        </TextBox>
+                    </StackPanel>
+                </StackPanel>
+            </ScrollViewer>
         </Grid>
 
         <Grid Grid.Row="4" Grid.ColumnSpan="10" Background="#FF18191B">

--- a/WPFUI/Views/CompareWindow.xaml
+++ b/WPFUI/Views/CompareWindow.xaml
@@ -316,6 +316,9 @@
 
         <Grid Grid.Row="2" Grid.Column="2" Grid.RowSpan="2">
             <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                <TextBlock FontSize="14" TextWrapping="Wrap" HorizontalAlignment="Center" Text="Type" />
+                <TextBlock Margin="0 0 0 40" FontSize="14" Foreground="DarkCyan" TextWrapping="Wrap" HorizontalAlignment="Center" FontWeight="Bold"
+                    Text="{Binding SelectedGridRow.Diff.Type}" />
                 <Button HorizontalAlignment="Center" VerticalAlignment="Center"
                     Command="{Binding DiscardComparedChangesCommand}">
                     <fa:ImageAwesome Icon="Solid_Xmark" Height="20" PrimaryColor="DarkCyan" />

--- a/WPFUI/Views/CompareWindow.xaml.cs
+++ b/WPFUI/Views/CompareWindow.xaml.cs
@@ -8,12 +8,4 @@ public partial class CompareWindow : Window
     {
         InitializeComponent();
     }
-
-    private void TextBox_CopyToClipboard(object sender, System.Windows.Input.MouseButtonEventArgs e)
-    {
-        if (sender is not System.Windows.Controls.TextBox textBox || string.IsNullOrEmpty(textBox.Text))
-            return;
-
-        Clipboard.SetText(textBox.Text);
-    }
 }

--- a/WPFUI/Views/MainWindow.xaml
+++ b/WPFUI/Views/MainWindow.xaml
@@ -328,59 +328,143 @@
         </Grid>
 
         <Grid Grid.Row="2" Grid.Column="2" x:Name="DetailedPanel" Grid.RowSpan="2">
-            <ScrollViewer BorderThickness="1 0 0 0" BorderBrush="Black">
-                <StackPanel Margin="5 5 5 5">
-                    <WrapPanel Orientation="Horizontal" Margin="5 5 0 5" VerticalAlignment="Center">
-                        <TextBlock VerticalAlignment="Center">Type</TextBlock>
-                        <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversation.Type}" />
-                    </WrapPanel>
-                    <WrapPanel Orientation="Horizontal" Margin="5 5 0 5">
-                        <TextBlock VerticalAlignment="Center">Name</TextBlock>
-                        <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversation.Name}" />
-                    </WrapPanel>
-                    <WrapPanel Orientation="Horizontal" Margin="5 5 0 5">
-                        <TextBlock VerticalAlignment="Center">Sound</TextBlock>
-                        <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversation.Sound}" />
-                    </WrapPanel>
-                    <WrapPanel Orientation="Horizontal" Margin="5 5 0 5">
-                        <TextBlock VerticalAlignment="Center">NPC Name</TextBlock>
-                        <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversation.NpcName}" />
-                    </WrapPanel>
-                    <WrapPanel Orientation="Horizontal" Margin="5 5 0 5">
-                        <TextBlock VerticalAlignment="Center">Context</TextBlock>
-                        <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversation.Context}" />
-                    </WrapPanel>
-                    <WrapPanel Orientation="Horizontal" Margin="5 5 0 5">
-                        <TextBlock VerticalAlignment="Center">Voice</TextBlock>
-                        <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversation.Voice}" />
-                    </WrapPanel>
-                    <WrapPanel Orientation="Horizontal" Margin="5 5 0 5">
-                        <TextBlock VerticalAlignment="Center">Number</TextBlock>
-                        <TextBox Style="{StaticResource SmoothTexBox}" MouseDoubleClick="TextBox_CopyToClipboard" Text="{Binding SelectedConversation.Number}" />
-                    </WrapPanel>
-                    <DockPanel LastChildFill="False">
-                        <WrapPanel DockPanel.Dock="Left" Orientation="Horizontal" Margin="5 5 0 5">
-                            <TextBlock VerticalAlignment="Center">Inspected</TextBlock>
-                            <CheckBox Margin="15 0 0 0" VerticalAlignment="Center" HorizontalAlignment="Center" IsChecked="{Binding SelectedConversation.IsInspected}"
+            <ScrollViewer BorderThickness="1 0 0 0" BorderBrush="Black" HorizontalScrollBarVisibility="Auto">
+                <StackPanel>
+                    <Grid Grid.IsSharedSizeScope="True" Margin="5 5 0 0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                        </Grid.RowDefinitions>
+
+                        <Grid Grid.Row="0" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0">Type</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Type}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Type" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.Type}" />
+                        </Grid>
+
+                        <Grid Grid.Row="1" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0">Name</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Name}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Name" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.Name}" />
+                        </Grid>
+
+                        <Grid Grid.Row="2" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0">Sound</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Sound}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Sound" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.Sound}" />
+                        </Grid>
+
+                        <Grid Grid.Row="3" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0">NPC Name</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=NpcName}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="NpcName" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.NpcName}" />
+                        </Grid>
+
+                        <Grid Grid.Row="4" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0">Context</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Context}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Context" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.Context}" />
+                        </Grid>
+
+                        <Grid Grid.Row="5" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0">Voice</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Voice}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Voice" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.Voice}" />
+                        </Grid>
+
+                        <Grid Grid.Row="6" Margin="5">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" SharedSizeGroup="Properties" />
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock VerticalAlignment="Center" Grid.Column="0">Number</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Number}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                            <TextBox x:Name="Number" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.Number}" />
+                        </Grid>
+
+                        <DockPanel LastChildFill="False" Grid.Row="7">
+                            <WrapPanel DockPanel.Dock="Left" Orientation="Horizontal" Margin="5 5 0 5">
+                                <TextBlock VerticalAlignment="Center">Inspected</TextBlock>
+                                <CheckBox Margin="15 0 0 0" VerticalAlignment="Center" HorizontalAlignment="Center" IsChecked="{Binding SelectedConversation.IsInspected}"
                             Command="{Binding ProjectFileChangedCommand}"/>
-                        </WrapPanel>
-                        <WrapPanel DockPanel.Dock="Right" Orientation="Horizontal" Margin="5 5 0 5">
-                            <TextBlock VerticalAlignment="Center">Edited</TextBlock>
-                            <CheckBox Margin="15 0 0 0" VerticalAlignment="Center" HorizontalAlignment="Center" Focusable="False" IsHitTestVisible="False" IsChecked="{Binding SelectedConversation.IsEdited}" />
-                        </WrapPanel>
-                    </DockPanel>
+                            </WrapPanel>
+                            <WrapPanel DockPanel.Dock="Right" Orientation="Horizontal" Margin="5 5 0 5">
+                                <TextBlock VerticalAlignment="Center">Edited</TextBlock>
+                                <CheckBox Margin="15 0 0 0" VerticalAlignment="Center" HorizontalAlignment="Center" Focusable="False" IsHitTestVisible="False" IsChecked="{Binding SelectedConversation.IsEdited}" />
+                            </WrapPanel>
+                        </DockPanel>
+                    </Grid>
+
                     <StackPanel Margin="5 15 0 5" HorizontalAlignment="Center">
-                        <TextBlock HorizontalAlignment="Center">Original Text</TextBlock>
-                        <TextBox VerticalScrollBarVisibility="Auto" Width="300" MinLines="3" MaxLines="10" Padding="4"
-                             TextWrapping="Wrap" MouseDoubleClick="TextBox_CopyToClipboard"
-                             IsReadOnly="True"
-                             Text="{Binding SelectedConversation.OriginalText}" />
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock HorizontalAlignment="Center">Original Text</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=OriginalText}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                        </StackPanel>
+                        <TextBox x:Name="OriginalText" VerticalScrollBarVisibility="Auto" Width="300" MinLines="3" MaxLines="10" Padding="4"
+                         TextWrapping="Wrap" IsReadOnly="True" Text="{Binding SelectedConversation.OriginalText}" />
                     </StackPanel>
                     <StackPanel Margin="5 15 0 5" HorizontalAlignment="Center">
-                        <TextBlock HorizontalAlignment="Center">Edited Text</TextBlock>
-                        <TextBox VerticalScrollBarVisibility="Auto" Width="300" MinLines="3" MaxLines="10" Padding="4"
-                             TextWrapping="Wrap" MouseDoubleClick="TextBox_CopyToClipboard"
-                             SpellCheck.IsEnabled="True" Language="pl-PL"
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <TextBlock HorizontalAlignment="Center">Edited Text</TextBlock>
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=EditedText}">
+                                <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
+                            </Button>
+                        </StackPanel>
+                        <TextBox x:Name="EditedText" VerticalScrollBarVisibility="Auto" Width="300" MinLines="3" MaxLines="10" Padding="4"
+                             TextWrapping="Wrap" SpellCheck.IsEnabled="True" Language="pl-PL"
                              Text="{Binding SelectedConversation.EditedText, UpdateSourceTrigger=PropertyChanged}">
                             <i:Interaction.Triggers>
                                 <i:EventTrigger EventName="TextChanged">
@@ -389,7 +473,6 @@
                             </i:Interaction.Triggers>
                         </TextBox>
                     </StackPanel>
-
                 </StackPanel>
             </ScrollViewer>
         </Grid>

--- a/WPFUI/Views/MainWindow.xaml
+++ b/WPFUI/Views/MainWindow.xaml
@@ -349,10 +349,10 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <TextBlock VerticalAlignment="Center" Grid.Column="0">Type</TextBlock>
-                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Type}">
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=DetailedPanel_Type}">
                                 <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
                             </Button>
-                            <TextBox x:Name="Type" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.Type}" />
+                            <TextBox x:Name="DetailedPanel_Type" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.Type}" />
                         </Grid>
 
                         <Grid Grid.Row="1" Margin="5">
@@ -362,10 +362,10 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <TextBlock VerticalAlignment="Center" Grid.Column="0">Name</TextBlock>
-                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Name}">
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=DetailedPanel_Name}">
                                 <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
                             </Button>
-                            <TextBox x:Name="Name" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.Name}" />
+                            <TextBox x:Name="DetailedPanel_Name" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.Name}" />
                         </Grid>
 
                         <Grid Grid.Row="2" Margin="5">
@@ -375,10 +375,10 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <TextBlock VerticalAlignment="Center" Grid.Column="0">Sound</TextBlock>
-                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Sound}">
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=DetailedPanel_Sound}">
                                 <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
                             </Button>
-                            <TextBox x:Name="Sound" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.Sound}" />
+                            <TextBox x:Name="DetailedPanel_Sound" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.Sound}" />
                         </Grid>
 
                         <Grid Grid.Row="3" Margin="5">
@@ -388,10 +388,10 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <TextBlock VerticalAlignment="Center" Grid.Column="0">NPC Name</TextBlock>
-                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=NpcName}">
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=DetailedPanel_NpcName}">
                                 <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
                             </Button>
-                            <TextBox x:Name="NpcName" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.NpcName}" />
+                            <TextBox x:Name="DetailedPanel_NpcName" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.NpcName}" />
                         </Grid>
 
                         <Grid Grid.Row="4" Margin="5">
@@ -401,10 +401,10 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <TextBlock VerticalAlignment="Center" Grid.Column="0">Context</TextBlock>
-                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Context}">
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=DetailedPanel_Context}">
                                 <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
                             </Button>
-                            <TextBox x:Name="Context" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.Context}" />
+                            <TextBox x:Name="DetailedPanel_Context" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.Context}" />
                         </Grid>
 
                         <Grid Grid.Row="5" Margin="5">
@@ -414,10 +414,10 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <TextBlock VerticalAlignment="Center" Grid.Column="0">Voice</TextBlock>
-                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Voice}">
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=DetailedPanel_Voice}">
                                 <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
                             </Button>
-                            <TextBox x:Name="Voice" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.Voice}" />
+                            <TextBox x:Name="DetailedPanel_Voice" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.Voice}" />
                         </Grid>
 
                         <Grid Grid.Row="6" Margin="5">
@@ -427,17 +427,17 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <TextBlock VerticalAlignment="Center" Grid.Column="0">Number</TextBlock>
-                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=Number}">
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=DetailedPanel_Number}">
                                 <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
                             </Button>
-                            <TextBox x:Name="Number" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.Number}" />
+                            <TextBox x:Name="DetailedPanel_Number" Grid.Column="2" Style="{StaticResource SmoothTexBox}" Text="{Binding SelectedConversation.Number}" />
                         </Grid>
 
                         <DockPanel LastChildFill="False" Grid.Row="7">
                             <WrapPanel DockPanel.Dock="Left" Orientation="Horizontal" Margin="5 5 0 5">
                                 <TextBlock VerticalAlignment="Center">Inspected</TextBlock>
                                 <CheckBox Margin="15 0 0 0" VerticalAlignment="Center" HorizontalAlignment="Center" IsChecked="{Binding SelectedConversation.IsInspected}"
-                            Command="{Binding ProjectFileChangedCommand}"/>
+                                    Command="{Binding ProjectFileChangedCommand}"/>
                             </WrapPanel>
                             <WrapPanel DockPanel.Dock="Right" Orientation="Horizontal" Margin="5 5 0 5">
                                 <TextBlock VerticalAlignment="Center">Edited</TextBlock>
@@ -449,21 +449,21 @@
                     <StackPanel Margin="5 15 0 5" HorizontalAlignment="Center">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                             <TextBlock HorizontalAlignment="Center">Original Text</TextBlock>
-                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=OriginalText}">
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=DetailedPanel_OriginalText}">
                                 <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
                             </Button>
                         </StackPanel>
-                        <TextBox x:Name="OriginalText" VerticalScrollBarVisibility="Auto" Width="300" MinLines="3" MaxLines="10" Padding="4"
-                         TextWrapping="Wrap" IsReadOnly="True" Text="{Binding SelectedConversation.OriginalText}" />
+                        <TextBox x:Name="DetailedPanel_OriginalText" VerticalScrollBarVisibility="Auto" Width="300" MinLines="3" MaxLines="10" Padding="4"
+                            TextWrapping="Wrap" IsReadOnly="True" Text="{Binding SelectedConversation.OriginalText}" />
                     </StackPanel>
                     <StackPanel Margin="5 15 0 5" HorizontalAlignment="Center">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                             <TextBlock HorizontalAlignment="Center">Edited Text</TextBlock>
-                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=EditedText}">
+                            <Button Style="{StaticResource CopyButton}" Grid.Column="1" Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Text, ElementName=DetailedPanel_EditedText}">
                                 <fa:ImageAwesome Icon="Regular_Copy" PrimaryColor="DarkCyan" />
                             </Button>
                         </StackPanel>
-                        <TextBox x:Name="EditedText" VerticalScrollBarVisibility="Auto" Width="300" MinLines="3" MaxLines="10" Padding="4"
+                        <TextBox x:Name="DetailedPanel_EditedText" VerticalScrollBarVisibility="Auto" Width="300" MinLines="3" MaxLines="10" Padding="4"
                              TextWrapping="Wrap" SpellCheck.IsEnabled="True" Language="pl-PL"
                              Text="{Binding SelectedConversation.EditedText, UpdateSourceTrigger=PropertyChanged}">
                             <i:Interaction.Triggers>

--- a/WPFUI/Views/MainWindow.xaml.cs
+++ b/WPFUI/Views/MainWindow.xaml.cs
@@ -8,12 +8,4 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
     }
-
-    private void TextBox_CopyToClipboard(object sender, System.Windows.Input.MouseButtonEventArgs e)
-    {
-        if (sender is not System.Windows.Controls.TextBox textBox || string.IsNullOrEmpty(textBox.Text))
-            return;
-
-        Clipboard.SetText(textBox.Text);
-    }
 }


### PR DESCRIPTION
Added **Copy to Clipboard** buttons near every property in Detailed Panel in normal and compare mode view.
Removed ability to double click on TextBox to copy to clipboard. It was hidden possibility. Now is more clear to click on button instead of TextBox.
Also in compare mode TexBlock with difference type has been added above Discard and Accept button.